### PR TITLE
Local Development Environment Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_STORE
 .idea
+.pyc
+__pycache__
+

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ The container is configured at runtime using the following environment variables
 
 ### Required Variables
 
-| Variable                                | Description                                                 |
-|-----------------------------------------|-------------------------------------------------------------|
+| Variable                                | Description                                               |
+|-----------------------------------------|-----------------------------------------------------------|
 | `JUPYTERHUB_COOKIE_SECRET_64_HEX_CHARS` | A 64-character hex string for securing user session cookies. |
-| `JUPYTERHUB_TEMPLATES_DIR`              | The path to custom HTML templates for login.                |
-| `KBASE_ORIGIN`                          | The KBase service URL used by the auth login html.          |
-| `KBASE_AUTH_URL`                        | The URL for the KBase authentication service.               |
-| `CDM_TASK_SERVICE_URL`                  | The URL for the CTS service.                                |
-| `GOVERNANCE_API_URL`                    | The URL for the Governance API.                             |
-| `MINIO_ENDPOINT_URL`                    | The endpoint URL for the MinIO object storage service.      |
-| `SPARK_CLUSTER_MANAGER_API_URL`         | The URL for the Spark Cluster Manager API.                  |
-| `BERDL_HIVE_METASTORE_URI`              | The URI for the Hive Metastore service.                     |
-| `BERDL_NOTEBOOK_IMAGE_TAG`              | The BERDL Compatible Notebook tag                           |
-
+| `JUPYTERHUB_TEMPLATES_DIR`              | The path to custom HTML templates for login.              |
+| `KBASE_ORIGIN`                          | The KBase service URL used by the auth login html.        |
+| `KBASE_AUTH_URL`                        | The URL for the KBase authentication service.             |
+| `CDM_TASK_SERVICE_URL`                  | The URL for the CTS service.                              |
+| `GOVERNANCE_API_URL`                    | The URL for the Governance API.                           |
+| `MINIO_ENDPOINT_URL`                    | The endpoint URL for the MinIO object storage service.    |
+| `SPARK_CLUSTER_MANAGER_API_URL`         | The URL for the Spark Cluster Manager API.                |
+| `BERDL_HIVE_METASTORE_URI`              | The URI for the Hive Metastore service.                   |
+| `BERDL_NOTEBOOK_IMAGE_TAG`              | The BERDL Compatible Notebook tag                         |
+| `BERDL_SKIP_SPAWN_HOOKS`                | If set, skips the spawn hooks for user notebook servers.  |
 ### Optional Variables
 
 | Variable                                | Default Value    | Description                                                                      |

--- a/berdlhub/config/hooks.py
+++ b/berdlhub/config/hooks.py
@@ -26,7 +26,7 @@ async def pre_spawn_hook(spawner):
     """
     spawner.log.debug("Pre-spawn hook called for user %s", spawner.user.name)
     kb_auth_token = await _get_auth_token(spawner)
-    if os.environ.get("BERDL_SKIP_SPAWN_HOOKS").lower() == "true":
+    if os.environ["BERDL_SKIP_SPAWN_HOOKS"].lower() == "true":
         spawner.log.info("Skipping pre-spawn hook due to BERDL_SKIP_SPAWN_HOOKS environment variable.")
         return
 
@@ -40,7 +40,7 @@ async def post_stop_hook(spawner):
     """
     kb_auth_token = await _get_auth_token(spawner)
     spawner.log.debug("Post-stop hook called for user %s", spawner.user.name)
-    if os.environ.get("BERDL_SKIP_SPAWN_HOOKS").lower() == "true":
+    if os.environ["BERDL_SKIP_SPAWN_HOOKS"].lower() == "true":
         spawner.log.info("Skipping post-stop hook due to BERDL_SKIP_SPAWN_HOOKS environment variable.")
         return
     await SparkClusterManager(kb_auth_token).stop_spark_cluster(spawner)

--- a/berdlhub/config/hooks.py
+++ b/berdlhub/config/hooks.py
@@ -1,3 +1,5 @@
+import os
+
 from kubernetes import client
 
 from berdlhub.api_utils.governance_utils import GovernanceUtils
@@ -24,6 +26,10 @@ async def pre_spawn_hook(spawner):
     """
     spawner.log.debug("Pre-spawn hook called for user %s", spawner.user.name)
     kb_auth_token = await _get_auth_token(spawner)
+    if os.environ.get("BERDL_SKIP_SPAWN_HOOKS").lower() == "true":
+        spawner.log.info("Skipping pre-spawn hook due to BERDL_SKIP_SPAWN_HOOKS environment variable.")
+        return
+
     await GovernanceUtils(kb_auth_token).set_governance_credentials(spawner)
     await SparkClusterManager(kb_auth_token).start_spark_cluster(spawner)
 
@@ -34,6 +40,9 @@ async def post_stop_hook(spawner):
     """
     kb_auth_token = await _get_auth_token(spawner)
     spawner.log.debug("Post-stop hook called for user %s", spawner.user.name)
+    if os.environ.get("BERDL_SKIP_SPAWN_HOOKS").lower() == "true":
+        spawner.log.info("Skipping post-stop hook due to BERDL_SKIP_SPAWN_HOOKS environment variable.")
+        return
     await SparkClusterManager(kb_auth_token).stop_spark_cluster(spawner)
 
 

--- a/berdlhub/config/validators.py
+++ b/berdlhub/config/validators.py
@@ -24,7 +24,7 @@ def validate_environment():
         "SPARK_CLUSTER_MANAGER_API_URL": "Spark cluster manager API",
         "BERDL_HIVE_METASTORE_URI": "Hive metastore URI",
         "BERDL_NOTEBOOK_IMAGE_TAG": "Docker image tag for the notebook server",
-        "BERDL_SKIP_SPAWN_HOOKS": "Skip pre and post spawn hooks",
+        "BERDL_SKIP_SPAWN_HOOKS": "Skip pre and post spawn hooks. Useful for local dev.",
     }
 
     optional_vars = {

--- a/berdlhub/config/validators.py
+++ b/berdlhub/config/validators.py
@@ -24,6 +24,7 @@ def validate_environment():
         "SPARK_CLUSTER_MANAGER_API_URL": "Spark cluster manager API",
         "BERDL_HIVE_METASTORE_URI": "Hive metastore URI",
         "BERDL_NOTEBOOK_IMAGE_TAG": "Docker image tag for the notebook server",
+        "BERDL_SKIP_SPAWN_HOOKS": "Skip pre and post spawn hooks",
     }
 
     optional_vars = {
@@ -41,7 +42,6 @@ def validate_environment():
         "JUPYTERHUB_MEM_LIMIT_GB": "Memory limit in GB for JupyterHub users. Defaults to 4GB",
         "JUPYTERHUB_MEM_GUARANTEE_GB": "Memory guarantee in GB for JupyterHub users. Defaults to 2GB",
         "JUPYTERHUB_CPU_LIMIT": "CPU limit for JupyterHub users. Defaults to 2 cores",
-        "BERDL_SKIP_SPAWN_HOOKS": "Skip pre and post spawn hooks. Defaults to False",
     }
 
     # Check required variables

--- a/berdlhub/config/validators.py
+++ b/berdlhub/config/validators.py
@@ -41,6 +41,7 @@ def validate_environment():
         "JUPYTERHUB_MEM_LIMIT_GB": "Memory limit in GB for JupyterHub users. Defaults to 4GB",
         "JUPYTERHUB_MEM_GUARANTEE_GB": "Memory guarantee in GB for JupyterHub users. Defaults to 2GB",
         "JUPYTERHUB_CPU_LIMIT": "CPU limit for JupyterHub users. Defaults to 2 cores",
+        "BERDL_SKIP_SPAWN_HOOKS": "Skip pre and post spawn hooks. Defaults to False",
     }
 
     # Check required variables

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -8,11 +8,37 @@ Deploy a local JupyterHub instance for BERDL development using Kubernetes.
 
 ## Deployment
 
+### Option 1: Using Pre-built Images (Recommended for Testing)
+
 ```bash
 kubectl apply -k local_dev/
 ```
 
-* Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.
+This uses the existing GitHub Container Registry images specified in the configuration files.
+
+### Option 2: Using Local Development Images
+
+If you want to test your local changes:
+
+1. **Build the image locally:**
+   ```bash
+   docker build -t berdl-jupyterhub:local .
+   ```
+
+2. **Update hub.yaml to use your local image:**
+   ```yaml
+   # In hub.yaml line 98, change:
+   image: ghcr.io/berdatalakehouse/berdl_jupyterhub:pr-3
+   # To:
+   image: berdl-jupyterhub:local
+   ```
+
+3. **Deploy:**
+   ```bash
+   kubectl apply -k local_dev/
+   ```
+
+### Alternative: Copy to Rancher UI
 * You can also copy them into the rancher2 UI to deploy them. Run `kustomize build . | pbcopy` to copy them to your clipboard.
 
 ## Configuration Files

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -3,16 +3,21 @@
 * These were adapted from https://gitlab.kbase.lbl.gov/berdl/configmaps and https://gitlab.kbase.lbl.gov/berdl/manifests using  `kustomize build . | pbcopy` within the directory to copy the k8 resources 
 
 # Deployment
-* Modify the configmaps in `local_dev/configmaps` to your local environment, such as NODE_SELECTOR
-* Deploy the configmaps with `kubectl apply -k local_dev/configmap.yaml` or drag/drop into the rancher2 desktop UI
-* Deploy the manifests with `kubectl apply -k local_dev/berdlhub.yaml` or drag/drop into the rancher2 desktop UI
+Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.
 
-# configmap.yaml
+
+# [configmap.yaml](configmap.yaml)
 * Modify the configmap and redeploy the hub to pick up the changes.
 * BERDL_NOTEBOOK_IMAGE_TAG = set to the tag of the BERDL compatible notebook image you want to use, such as `berdl-notebook:latest`
 
-# hub.yaml
-* Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images.
+# [hub.yaml](hub.yaml)
+* Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images or a locally built image.
 
-# Port Forwarding
-kubectl port-forward deployment/jupyterhub 8000:8000 --namespace=jupyterhub-dev
+
+# [ingress.yaml](hub.yaml)
+* Ensure your hosts file matches the ingress host such as
+```aiignore
+127.0.0.1 cdmhub.ci.kbase.us
+127.0.0.1 hub.berdl.kbase.us
+```
+* you can get a copy of the TLS cert from our rancher if you want, otherwise you will have to use chrome and type 'thisisunsafe'

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -1,22 +1,34 @@
-# Info
-* Deploy k8 resources into your local cluster, such as rancher2 desktop
-* These were adapted from https://gitlab.kbase.lbl.gov/berdl/configmaps and https://gitlab.kbase.lbl.gov/berdl/manifests using  `kustomize build . | pbcopy` within the directory to copy the k8 resources 
+# BERDL JupyterHub Local Development
 
-# Deployment
-Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.
+Deploy a local JupyterHub instance for BERDL development using Kubernetes.
 
+## Info
+* Deploy Kubernetes resources into your local cluster, such as Rancher Desktop
+* These were adapted from https://gitlab.kbase.lbl.gov/berdl/configmaps and https://gitlab.kbase.lbl.gov/berdl/manifests using `kustomize build . | pbcopy` within the directory to copy the k8 resources 
 
-# [configmap.yaml](configmap.yaml)
+## Deployment
+
+```bash
+kubectl apply -k local_dev/
+```
+
+* Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.
+* You can also you can copy them into the rancher2 UI to deploy them. Run `kustomize build . | pbcopy` to copy them to your clipboard.
+
+## Configuration Files
+
+### [configmap.yaml](configmap.yaml)
 * Modify the configmap and redeploy the hub to pick up the changes.
 * BERDL_NOTEBOOK_IMAGE_TAG = set to the tag of the BERDL compatible notebook image you want to use, such as `berdl-notebook:latest`
 
-# [hub.yaml](hub.yaml)
+### [hub.yaml](hub.yaml)
 * Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images or a locally built image.
 
-
-# [ingress.yaml](ingress.yaml)
-* Ensure your hosts file matches the ingress host such as
+### [ingress.yaml](ingress.yaml)
+* Ensure your hosts file matches the ingress host:
+```
 127.0.0.1 cdmhub.ci.kbase.us
 127.0.0.1 hub.berdl.kbase.us
 ```
-* you can get a copy of the TLS cert from our rancher if you want, otherwise you will have to use chrome and type 'thisisunsafe'
+* You can get a copy of the TLS cert from our rancher if you want, otherwise you will have to use chrome and type 'thisisunsafe'
+* This TLS cert should not be distributed outside of your local environment.

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -1,0 +1,18 @@
+# Info
+* Deploy k8 resources into your local cluster, such as rancher2 desktop
+* These were adapted from https://gitlab.kbase.lbl.gov/berdl/configmaps and https://gitlab.kbase.lbl.gov/berdl/manifests using  `kustomize build . | pbcopy` within the directory to copy the k8 resources 
+
+# Deployment
+* Modify the configmaps in `local_dev/configmaps` to your local environment, such as NODE_SELECTOR
+* Deploy the configmaps with `kubectl apply -k local_dev/configmap.yaml` or drag/drop into the rancher2 desktop UI
+* Deploy the manifests with `kubectl apply -k local_dev/berdlhub.yaml` or drag/drop into the rancher2 desktop UI
+
+# configmap.yaml
+* Modify the configmap and redeploy the hub to pick up the changes.
+* BERDL_NOTEBOOK_IMAGE_TAG = set to the tag of the BERDL compatible notebook image you want to use, such as `berdl-notebook:latest`
+
+# hub.yaml
+* Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images.
+
+# Port Forwarding
+kubectl port-forward deployment/jupyterhub 8000:8000 --namespace=jupyterhub-dev

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -13,7 +13,7 @@ kubectl apply -k local_dev/
 ```
 
 * Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.
-* You can also you can copy them into the rancher2 UI to deploy them. Run `kustomize build . | pbcopy` to copy them to your clipboard.
+* You can also copy them into the rancher2 UI to deploy them. Run `kustomize build . | pbcopy` to copy them to your clipboard.
 
 ## Configuration Files
 

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -14,7 +14,7 @@ Use the provided local_dev directory to deploy the JupyterHub instance. This dir
 * Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images or a locally built image.
 
 
-# [ingress.yaml](hub.yaml)
+# [ingress.yaml](ingress.yaml)
 * Ensure your hosts file matches the ingress host such as
 ```aiignore
 127.0.0.1 cdmhub.ci.kbase.us

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -16,7 +16,6 @@ Use the provided local_dev directory to deploy the JupyterHub instance. This dir
 
 # [ingress.yaml](ingress.yaml)
 * Ensure your hosts file matches the ingress host such as
-```aiignore
 127.0.0.1 cdmhub.ci.kbase.us
 127.0.0.1 hub.berdl.kbase.us
 ```

--- a/local_dev/configmap.yaml
+++ b/local_dev/configmap.yaml
@@ -1,0 +1,21 @@
+kind: ConfigMap
+metadata:
+   name: jupyterhub-config
+   namespace: jupyterhub-dev
+apiVersion: v1
+data:
+  BERDL_HIVE_METASTORE_URI: http://hive-metastore:9083
+  BERDL_NOTEBOOK_IMAGE_TAG: ghcr.io/bio-boris/berdl_notebook:main
+  CDM_TASK_SERVICE_URL: https://berdl.kbase.us/apis/cts
+  GOVERNANCE_API_URL: http://minio-service:8000
+  JUPYTERHUB_COOKIE_SECRET_64_HEX_CHARS: d1a3f8a56c4b27e939f81bc6dfcd3e81913a2b79e5f4674a6bd37f5e4a29de38
+  JUPYTERHUB_CRYPT_KEY: 7b40d6e5c09f34a721e8a9f05bfc6c2e3a41d8f97c63b28eab249fd89c1e0737
+  JUPYTERHUB_IDLE_TIMEOUT_SECONDS: '3600'
+  KBASE_AUTH_URL: https://narrative.kbase.us/services/auth/
+  KBASE_ORIGIN: https://narrative.kbase.us
+  MINIO_ENDPOINT_URL: https://minio.berdl.kbase.us
+  MINIO_SECURE_FLAG: 'True'
+  NODE_SELECTOR_HOSTNAME: lima-rancher-desktop
+  SPARK_CLUSTER_MANAGER_API_URL: http://sparkmanagerapi:8000
+
+

--- a/local_dev/configmap.yaml
+++ b/local_dev/configmap.yaml
@@ -17,5 +17,6 @@ data:
   MINIO_SECURE_FLAG: 'True'
   NODE_SELECTOR_HOSTNAME: lima-rancher-desktop
   SPARK_CLUSTER_MANAGER_API_URL: http://sparkmanagerapi:8000
+  BERDL_SKIP_SPAWN_HOOKS: 'True'
 
 

--- a/local_dev/hub.yaml
+++ b/local_dev/hub.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: jupyterhub-dev
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jupyterhub-user-pod-creator
@@ -67,7 +62,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: jupyterhub
+    app.kubernetes.io/name: berdlhub
   name: jupyterhub
   namespace: jupyterhub-dev
 spec:
@@ -75,33 +70,33 @@ spec:
   - port: 8000
     targetPort: 8000
   selector:
-    app.kubernetes.io/name: jupyterhub
+    app.kubernetes.io/name: berdlhub
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: jupyterhub
-  name: jupyterhub
+    app.kubernetes.io/name: berdlhub
+  name: berdlhub
   namespace: jupyterhub-dev
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: jupyterhub
+      app.kubernetes.io/name: berdlhub
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: jupyterhub
+        app.kubernetes.io/name: berdlhub
     spec:
       containers:
       - envFrom:
         - configMapRef:
             name: jupyterhub-config
-        image: ghcr.io/berdatalakehouse/berdl_jupyterhub:pr-1
-        name: jupyterhub
+        image: ghcr.io/berdatalakehouse/berdl_jupyterhub:pr-3 # Change this!
+        name: berdlhub
         ports:
         - containerPort: 8000
         readinessProbe:
@@ -129,9 +124,11 @@ spec:
 #        volumeMounts:
 #        - mountPath: /srv/jupyterhub
 #          name: jupyterhub-data
+#      nodeSelector:
+#        kubernetes.io/hostname: kworker02
       serviceAccountName: jupyterhub-user-pod-creator
 #      volumes:
 #      - hostPath:
-#          path: /mnt/state/jupyterhub-dev
+#          path: /mnt/state/jupyterhub-{env}
 #          type: Directory
 #        name: jupyterhub-data

--- a/local_dev/hub.yaml
+++ b/local_dev/hub.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jupyterhub-dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jupyterhub-user-pod-creator
+  namespace: jupyterhub-dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jupyterhub-user-pod-creator
+  namespace: jupyterhub-dev
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/attach
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jupyterhub-user-pod-creator-binding
+  namespace: jupyterhub-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jupyterhub-user-pod-creator
+subjects:
+- kind: ServiceAccount
+  name: jupyterhub-user-pod-creator
+  namespace: jupyterhub-dev
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: jupyterhub
+  name: jupyterhub
+  namespace: jupyterhub-dev
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app.kubernetes.io/name: jupyterhub
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: jupyterhub
+  name: jupyterhub
+  namespace: jupyterhub-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jupyterhub
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jupyterhub
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: jupyterhub-config
+        image: ghcr.io/berdatalakehouse/berdl_jupyterhub:pr-1
+        name: jupyterhub
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - NET_BIND_SERVICE
+            - SETGID
+            - SETUID
+            drop:
+            - ALL
+#        volumeMounts:
+#        - mountPath: /srv/jupyterhub
+#          name: jupyterhub-data
+      serviceAccountName: jupyterhub-user-pod-creator
+#      volumes:
+#      - hostPath:
+#          path: /mnt/state/jupyterhub-dev
+#          type: Directory
+#        name: jupyterhub-data

--- a/local_dev/ingress.yaml
+++ b/local_dev/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jupyterhub-ingress
+  namespace: jupyterhub-dev
+spec:
+  tls:
+  - hosts:
+    - hub.berdl.kbase.us
+  rules:
+  - host: hub.berdl.kbase.us
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: jupyterhub
+            port:
+              number: 8000

--- a/local_dev/kustomization.yaml
+++ b/local_dev/kustomization.yaml
@@ -1,6 +1,7 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
+  - namespace.yaml
   - configmap.yaml
   - hub.yaml
   - ingress.yaml

--- a/local_dev/kustomization.yaml
+++ b/local_dev/kustomization.yaml
@@ -1,0 +1,6 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - configmap.yaml
+  - hub.yaml
+  - ingress.yaml

--- a/local_dev/namespace.yaml
+++ b/local_dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jupyterhub-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "jupyterhub-idle-culler==1.4.0",
     "jupyterhub-kubespawner==7.0.0",
     "kubernetes>=33.1.0",
-
 ]
 
 


### PR DESCRIPTION
This sets up changes needed to deploy jupyterhub locally.

# Info
* Deploy k8 resources into your local cluster, such as rancher2 desktop
* These were adapted from https://gitlab.kbase.lbl.gov/berdl/configmaps and https://gitlab.kbase.lbl.gov/berdl/manifests using  `kustomize build . | pbcopy` within the directory to copy the k8 resources 

# Deployment
Use the provided local_dev directory to deploy the JupyterHub instance. This directory contains all necessary Kubernetes manifests and configurations.


# [configmap.yaml](configmap.yaml)
* Modify the configmap and redeploy the hub to pick up the changes.
* BERDL_NOTEBOOK_IMAGE_TAG = set to the tag of the BERDL compatible notebook image you want to use, such as `berdl-notebook:latest`

# [hub.yaml](hub.yaml)
* Modify the image tag to the tag of the BERDL JupyterHub image you want to use, you can build it locally or open a PR, and use the ghcr.io created images or a locally built image.


# [ingress.yaml](hub.yaml)
* Ensure your hosts file matches the ingress host such as
```aiignore
127.0.0.1 cdmhub.ci.kbase.us
127.0.0.1 hub.berdl.kbase.us
```
* you can get a copy of the TLS cert from our rancher if you want, otherwise you will have to use chrome and type 'thisisunsafe'
