### PR TITLE
Add Trino env vars to notebook pods

### DIFF
--- a/berdlhub/config/environment.py
+++ b/berdlhub/config/environment.py
@@ -49,6 +49,9 @@ def configure_environment(c):
         # This must match the Service name created in spark_connect_service.py
         "SPARK_CONNECT_URL": get_spark_connect_url,
         "TENANT_ACCESS_SERVICE_URL": os.environ["TENANT_ACCESS_SERVICE_URL"],
+        # Trino
+        "TRINO_HOST": os.environ.get("TRINO_HOST", "trino"),
+        "TRINO_PORT": os.environ.get("TRINO_PORT", "8080"),
     }
 
     # Jupyter Docker Stacks configuration


### PR DESCRIPTION
## Summary
- Inject `TRINO_HOST` and `TRINO_PORT` into spawned notebook pods via KubeSpawner environment
- Defaults to `trino:8080` if not set on the JupyterHub pod
- Required for `get_trino_connection()` in spark_notebook (see BERDataLakehouse/spark_notebook#141)

## Test plan
- [ ] Verify env vars appear in spawned notebook pod (`os.environ["TRINO_HOST"]`)
- [ ] Verify `get_trino_connection()` connects using injected values